### PR TITLE
[DO NOT MERGE YET]: Split Rake codebase between an actual binary and a reusable core library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler2"
-version = "2.0.0"
+name = "adler"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "anstream"
@@ -80,17 +80,17 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
 ]
 
 [[package]]
@@ -177,6 +177,33 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -271,6 +298,16 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -372,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
@@ -665,6 +702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +744,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -740,11 +789,11 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
- "adler2",
+ "adler",
 ]
 
 [[package]]
@@ -777,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -833,6 +882,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "percent-encoding"
@@ -890,6 +945,7 @@ name = "rake"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "color-eyre",
  "heck",
  "hex",
  "rand",
@@ -1151,6 +1207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1336,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,6 +1456,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1429,6 +1526,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ heck = "0.5.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+color-eyre = "0.6.3"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,2 @@
+pub const MAX_ITER_COUNT: u64 = 0xffffffffffff; // TODO: Temporarily until we handle the math better.
+pub const PREPOSITIONS: [&'static str; 8] = ["as", "of", "for", "by", "like", "in", "from", "into"];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,160 @@
+use heck::ToTitleCase;
+use rand::{seq::IteratorRandom, Rng};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+use tiny_keccak::{Hasher, Keccak};
+
+pub mod constants;
+use constants::MAX_ITER_COUNT;
+
+pub struct RakeFlags {
+    dictionary: Vec<String>,
+    func_args: String,
+    match_selector: String,
+    openchain: bool,
+}
+
+impl RakeFlags {
+    pub fn new(
+        dictionary: Vec<String>,
+        func_args: String,
+        match_selector: String,
+        openchain: bool,
+    ) -> Self {
+        Self {
+            dictionary,
+            func_args,
+            match_selector,
+            openchain,
+        }
+    }
+
+    pub fn builder() -> RakeBuilder {
+        RakeBuilder::default()
+    }
+}
+
+#[derive(Default)]
+pub struct RakeBuilder {
+    dictionary: Vec<String>,
+    func_args: String,
+    match_selector: String,
+    openchain: bool,
+}
+
+impl RakeBuilder {
+    pub fn new() -> Self {
+        Self {
+            dictionary: Vec::new(),
+            func_args: String::default(),
+            match_selector: String::default(),
+            openchain: false,
+        }
+    }
+    pub fn build(self) -> RakeFlags {
+        RakeFlags {
+            dictionary: self.dictionary,
+            func_args: self.func_args,
+            match_selector: self.match_selector,
+            openchain: self.openchain,
+        }
+    }
+
+    pub fn dictionary(mut self, dictionary: Vec<String>) -> Self {
+        self.dictionary = dictionary;
+        self
+    }
+
+    pub fn function_args(mut self, func_args: String) -> Self {
+        self.func_args = func_args;
+        self
+    }
+
+    pub fn match_selector(mut self, selector: String) -> Self {
+        self.match_selector = selector;
+        self
+    }
+
+    pub fn with_openchain(mut self, openchain: bool) -> Self {
+        self.openchain = openchain;
+        self
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct OpenchainImportParams {
+    function: Vec<String>,
+}
+
+pub fn start_cracking(args: RakeFlags) {
+    // Calculate total possibilities.
+    //let num_possible = fact(u128::try_from(args.dictionary.len()).unwrap() * 2_u128);
+    // TODO: Handle the above ^ math better
+    println!("Dictionary loaded: {:?}", args.dictionary);
+    println!(
+        "Iterating over {} total possibilities or factorial({})",
+        0,
+        args.dictionary.len() * 2
+    );
+    let hasher = Keccak::v256();
+    let sig_list = Arc::new(RwLock::new(HashMap::new()));
+
+    // Spawn iterators and calculate the hashes.
+    (0..MAX_ITER_COUNT).into_par_iter().for_each(|_| {
+        let sig_map = sig_list.clone();
+        let mut rng = rand::thread_rng();
+        let total_words: u128 = rng.gen_range(0..u128::try_from(args.dictionary.len()).unwrap());
+        let word_sample = args
+            .dictionary
+            .iter()
+            .choose_multiple(&mut rng, total_words.try_into().unwrap());
+        let mut func_name = String::new();
+        for (idx, word) in word_sample.iter().enumerate() {
+            if idx == 0 {
+                func_name.push_str(word.as_str());
+            } else {
+                func_name.push_str(word.to_title_case().as_str());
+            }
+        }
+        let mut hash = hasher.clone();
+        let mut hash_result = [0u8; 32];
+        let func_sig = format!("{}({})", func_name, args.func_args);
+        hash.update(func_sig.as_bytes());
+        hash.finalize(&mut hash_result);
+        let func_selector = hex::encode(hash_result[..4].to_vec());
+        let map = sig_map.read().expect("Poisoned RwLock");
+        if map.contains_key(&func_selector) {
+            return;
+        }
+        drop(map);
+        let mut map = sig_map.write().expect("Poisoned RwLock");
+        map.insert(func_selector.clone(), func_sig.clone());
+        if func_selector == args.match_selector {
+            println!(
+                "Found target function signature for {}: {}",
+                args.match_selector, func_sig
+            );
+            if args.openchain {
+                println!("Submitting to Openchain...");
+                let openchain_params = OpenchainImportParams {
+                    function: vec![func_sig],
+                };
+                let client = reqwest::blocking::Client::new();
+                client
+                    .post("https://api.openchain.xyz/signature-database/v1/import")
+                    .header("accept", "application/json")
+                    .header("Content-Type", "application/json")
+                    .json(&openchain_params)
+                    .send()
+                    .unwrap();
+                println!("Signature successfully submitted!");
+            }
+            std::process::exit(1);
+        }
+        println!("function {} => {}", func_sig, func_selector);
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,11 +118,16 @@ pub fn start_cracking(args: RakeFlags) -> Result<Receiver<FunctionData>> {
     (0..MAX_ITER_COUNT).into_par_iter().for_each(|_| {
         let sig_map = sig_list.clone();
         let mut rng = rand::thread_rng();
-        let total_words: u128 = rng.gen_range(0..u128::try_from(args.dictionary.len()).unwrap());
-        let word_sample = args
-            .dictionary
-            .iter()
-            .choose_multiple(&mut rng, total_words.try_into().unwrap());
+        let total_words: u128 = rng.gen_range(
+            0..u128::try_from(args.dictionary.len())
+                .expect("Unexpected failure whilst converting dictionary length to uint128"),
+        );
+        let word_sample = args.dictionary.iter().choose_multiple(
+            &mut rng,
+            total_words
+                .try_into()
+                .expect("Unexpected failure whilst converting dictionary total words into usize"),
+        );
         let mut func_name = String::new();
         for (idx, word) in word_sample.iter().enumerate() {
             if idx == 0 {
@@ -161,7 +166,7 @@ pub fn start_cracking(args: RakeFlags) -> Result<Receiver<FunctionData>> {
                     .header("Content-Type", "application/json")
                     .json(&openchain_params)
                     .send()
-                    .unwrap();
+                    .expect("Failed to upload function signature to Openchain.xyz");
                 println!("Signature successfully submitted!");
             }
             std::process::exit(1);
@@ -170,7 +175,7 @@ pub fn start_cracking(args: RakeFlags) -> Result<Receiver<FunctionData>> {
             signature: func_sig,
             selector: func_selector,
         })
-        .unwrap();
+        .expect("Failed to send function data to mpsc receiver");
     });
 
     Ok(rx)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use color_eyre::eyre::Result;
 use rake::{constants::PREPOSITIONS, start_cracking, RakeBuilder};
 
 #[derive(Parser, Debug)]
@@ -50,7 +51,8 @@ impl Args {
     }
 }
 
-fn main() {
+fn main() -> Result<()> {
+    color_eyre::install()?;
     let mut args = Args::parse();
     if args.prepositions {
         args.append_prepositions();
@@ -61,5 +63,6 @@ fn main() {
         .match_selector(args.match_selector)
         .with_openchain(args.openchain)
         .build();
-    start_cracking(flags);
+    start_cracking(flags)?;
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,5 @@
 use clap::Parser;
-use heck::ToTitleCase;
-use rand::{seq::IteratorRandom, Rng};
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
-use tiny_keccak::{Hasher, Keccak};
-
-const MAX_ITER_COUNT: u64 = 0xffffffffffff; // TODO: Temporarily until we handle the math better.
-const PREPOSITIONS: [&'static str; 8] = ["as", "of", "for", "by", "like", "in", "from", "into"];
+use rake::{constants::PREPOSITIONS, start_cracking, RakeBuilder};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -21,47 +10,44 @@ struct Args {
         help = "List of known words to use in an attempt to brute force a matching signature",
         required = true
     )]
-    dictionary: Vec<String>,
+    pub dictionary: Vec<String>,
     #[arg(
         short = 'a',
         long = "args",
         help = "Arguments of the function being brute forced, used for constructing a valid signature"
     )]
-    func_args: String,
+    pub func_args: String,
+    #[arg(short = 'i', long, help = "Open Rake inside of an interactive TUI")]
+    pub interactive: bool,
     #[arg(
         short = 'm',
         long,
         default_value = "00000000",
         help = "Selector to attempt to create a matching signature for"
     )]
-    match_selector: String,
+    pub match_selector: String,
     #[arg(
         short = 'o',
         long,
         default_value = "false",
         help = "Enable to submit the matching signature to Openchain after a successful match"
     )]
-    openchain: bool,
+    pub openchain: bool,
     #[arg(
         short = 'p',
         long,
         default_value = "false",
         long_help = "Append a few common English prepositions (as, of, for, by, like, in, from, into) to the dictionary. Adds potential accuracy to brute forcing whilst adding some additional overhead cost due to additional combinations to sift through"
     )]
-    prepositions: bool,
+    pub prepositions: bool,
 }
 
 impl Args {
-    fn append_prepositions(&mut self) {
+    pub fn append_prepositions(&mut self) {
         for prep in PREPOSITIONS.into_iter() {
             self.dictionary.push(prep.to_string());
         }
     }
-}
-
-#[derive(Serialize, Deserialize)]
-struct OpenchainImportParams {
-    function: Vec<String>,
 }
 
 fn main() {
@@ -69,78 +55,11 @@ fn main() {
     if args.prepositions {
         args.append_prepositions();
     }
-    start_cracking(args);
-}
-
-fn fact(num: u128) -> u128 {
-    (1..=num).product()
-}
-
-fn start_cracking(args: Args) {
-    // Calculate total possibilities.
-    //let num_possible = fact(u128::try_from(args.dictionary.len()).unwrap() * 2_u128);
-    // TODO: Handle the above ^ math better
-    println!("Dictionary loaded: {:?}", args.dictionary);
-    println!(
-        "Iterating over {} total possibilities or factorial({})",
-        0,
-        args.dictionary.len() * 2
-    );
-    let mut hasher = Keccak::v256();
-    let sig_list = Arc::new(RwLock::new(HashMap::new()));
-
-    // Spawn iterators and calculate the hashes.
-    (0..MAX_ITER_COUNT).into_par_iter().for_each(|_| {
-        let sig_map = sig_list.clone();
-        let mut rng = rand::thread_rng();
-        let total_words: u128 = rng.gen_range(0..u128::try_from(args.dictionary.len()).unwrap());
-        let word_sample = args
-            .dictionary
-            .iter()
-            .choose_multiple(&mut rng, total_words.try_into().unwrap());
-        let mut func_name = String::new();
-        for (idx, word) in word_sample.iter().enumerate() {
-            if idx == 0 {
-                func_name.push_str(word.as_str());
-            } else {
-                func_name.push_str(word.to_title_case().as_str());
-            }
-        }
-        let mut hash = hasher.clone();
-        let mut hash_result = [0u8; 32];
-        let func_sig = format!("{}({})", func_name, args.func_args);
-        hash.update(func_sig.as_bytes());
-        hash.finalize(&mut hash_result);
-        let func_selector = hex::encode(hash_result[..4].to_vec());
-        let map = sig_map.read().expect("Poisoned RwLock");
-        if map.contains_key(&func_selector) {
-            return;
-        }
-        drop(map);
-        let mut map = sig_map.write().expect("Poisoned RwLock");
-        map.insert(func_selector.clone(), func_sig.clone());
-        if func_selector == args.match_selector {
-            println!(
-                "Found target function signature for {}: {}",
-                args.match_selector, func_sig
-            );
-            if args.openchain {
-                println!("Submitting to Openchain...");
-                let openchain_params = OpenchainImportParams {
-                    function: vec![func_sig],
-                };
-                let client = reqwest::blocking::Client::new();
-                client
-                    .post("https://api.openchain.xyz/signature-database/v1/import")
-                    .header("accept", "application/json")
-                    .header("Content-Type", "application/json")
-                    .json(&openchain_params)
-                    .send()
-                    .unwrap();
-                println!("Signature successfully submitted!");
-            }
-            std::process::exit(1);
-        }
-        println!("function {} => {}", func_sig, func_selector);
-    });
+    let flags = RakeBuilder::new()
+        .dictionary(args.dictionary)
+        .function_args(args.func_args)
+        .match_selector(args.match_selector)
+        .with_openchain(args.openchain)
+        .build();
+    start_cracking(flags);
 }


### PR DESCRIPTION
Splits the binary and library between ``main.rs`` & ``lib.rs`` and implements better code composability to enable integrating Rake into other Rust codebases, as well as paving the way for more complex modes for brute forcing function signatures.